### PR TITLE
Add courrelate zipkin consumer, split zipkin-prod into web/receiver

### DIFF
--- a/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/CourrelateProducer.scala
+++ b/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/CourrelateProducer.scala
@@ -1,0 +1,42 @@
+package org.coursera.zipkin.courrelate
+
+import java.util.Properties
+
+import com.twitter.logging.Logger
+import kafka.javaapi.producer.Producer
+import kafka.producer.KeyedMessage
+import kafka.producer.ProducerConfig
+import play.api.libs.json.Json
+
+import scala.collection.JavaConverters._
+
+class CourrelateProducer {
+  val logger = Logger.get(classOf[CourrelateProducer])
+
+  import Formats._
+
+  private[this] val producer = {
+    val downstreamKafkaBrokerList = System.getProperty("downstreamKafka.metadata.broker.list")
+
+    val props = new Properties()
+    props.put("metadata.broker.list", downstreamKafkaBrokerList)
+    props.put("serializer.class", "kafka.serializer.StringEncoder")
+    props.put("request.required.acks", "1")
+    props.put("producer.type", "async")
+    props.put("compression.codec", "gzip")
+
+    val producerConfig = new ProducerConfig(props)
+    new Producer[String, String](producerConfig)
+  }
+
+  def send(spans: Seq[RichSpan]): Unit = {
+    val messages = spans.map { span =>
+      val jsonString = Json.stringify(Json.toJson(span))
+      logger.ifDebug(s"Sending JSON to Kafka: $jsonString")
+
+      new KeyedMessage[String, String]("courrelate", span.spanId.toString, jsonString)
+    }
+
+    producer.send(messages.toList.asJava)
+  }
+}

--- a/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/Main.scala
+++ b/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/Main.scala
@@ -1,0 +1,139 @@
+package org.coursera.zipkin.courrelate
+
+import com.google.common.net.InetAddresses
+import com.twitter.logging.Logger
+import com.twitter.scrooge.BinaryThriftStructSerializer
+import com.twitter.util.Base64StringEncoder
+import com.twitter.server.{Closer, TwitterServer}
+import com.twitter.util.{Await, Closable, Future}
+import com.twitter.zipkin.receiver.kafka.KafkaProcessor
+import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
+import com.twitter.zipkin.thriftscala.Constants
+import com.twitter.zipkin.{thriftscala => thrift}
+import org.apache.log4j.ConsoleAppender
+import org.apache.log4j.Level
+import org.apache.log4j.PatternLayout
+import scala.util.Try
+
+object StringDecoder extends KafkaProcessor.KafkaDecoder {
+  private[this] val deserializer = new BinaryThriftStructSerializer[thrift.Span] {
+    override val encoder = Base64StringEncoder
+    val codec = thrift.Span
+  }
+
+  override def fromBytes(
+    bytes: Array[Byte]): Option[List[thrift.Span]] = {
+
+    val s = new String(bytes)
+    Some(s.split(",").flatMap(d => Try(deserializer.fromString(d)).toOption).toList)
+  }
+}
+
+object Main extends TwitterServer with KafkaSpanReceiverFactory with Closer {
+  // initialize logging (Kafka uses log4j)
+  val logger = Logger.get("Main")
+  val root = org.apache.log4j.Logger.getRootLogger()
+  root.addAppender(new ConsoleAppender(new PatternLayout("%r [%t] %p %c %x - %m%n")))
+  root.setLevel(Level.INFO)
+  
+
+  import SpanUtils._
+
+  val producer = new CourrelateProducer()
+
+
+  def main(): Unit = {
+    var (totalReceived, totalServerReceived, totalProcessed) = (0, 0, 0)
+
+    def process(spans: Seq[thrift.Span]): Future[Unit] = {
+
+      // we ignore client spans, as a) the timings are off and b) they're only useful in debugging
+      // a handful of issues
+      val serverSpans = spans.filter { span =>
+        totalReceived += 1
+
+        logger.ifDebug(s"Processing ${spans.size} spans")
+        logger.ifDebug(printSpan(span))
+
+        // we're looking for server spans that have the new set of denormalized to/From annotations
+        val isServerSpan = span.annotations.exists(
+          ann => (ann.value == Constants.SERVER_RECV || ann.value == Constants.SERVER_SEND))
+        val isV2 = getBinaryAnnotationValue(span, "fromServiceName").isDefined
+
+        isServerSpan && isV2
+      }.map { span =>
+        totalServerReceived += 1
+        val spanId = new java.lang.Long(span.id)
+        val parentSpanId = span.parentId
+
+        // note: timestamp and duration are in millis!
+        val recvTimestamp = span.annotations.find(_.value == Constants.SERVER_RECV).map(_.timestamp)
+        val sendTimestamp = span.annotations.find(_.value == Constants.SERVER_SEND).map(_.timestamp)
+        val (timestamp, duration) = (for {
+          recv <- recvTimestamp
+          send <- sendTimestamp
+        } yield (recv / 1000L, (send - recv) / 1000L)).getOrElse((-1L, -1L))
+
+        def serviceAnnotations(span: thrift.Span, prefix: String): ServiceInstance = {
+          val hostIp: Option[Integer] = getBinaryAnnotationValue(span, prefix + "ServiceHostIp")
+          ServiceInstance(
+            getBinaryAnnotationValue(span, prefix + "ServiceName"),
+            getBinaryAnnotationValue(span, prefix + "ServiceVersion"),
+            hostIp.map(InetAddresses.fromInteger(_).getHostAddress)
+          )
+        }
+
+        val fromService = serviceAnnotations(span, "from")
+        val toService = serviceAnnotations(span, "to")
+
+        val requestUri = getBinaryAnnotationValue(span, "requestUri").getOrElse("__none__")
+        val callDepth =  20 - getBinaryAnnotationValue(span, "rpcsRemaining").getOrElse(-1)
+
+        // Note: status can be String or Int
+        // See https://github.com/webedx-spark/infra-services/blob/master/playcour/playcour/app/org/coursera/playcour/filters/TraceServerFilter.scala#L89
+        val status: Any = getBinaryAnnotationValue(span, "status").getOrElse(-1)
+        val statusInt = status match {
+          case s: Int => s
+          case s: String => Integer.parseInt(s)
+          case _ => throw new IllegalArgumentException("Invalid status code type: " + status.getClass)
+        }
+
+        totalProcessed += 1
+
+        if (totalReceived % 1000 == 0) {
+          logger.info(s"""|Processing stats: $totalReceived received, $totalServerReceived server
+                          |spans, $totalProcessed processed""".stripMargin)
+        }
+
+        RichSpan(
+          timestamp,
+          span.traceId.toString,
+          spanId,
+          parentSpanId,
+          fromService.name,
+          fromService.version,
+          fromService.hostIp,
+          toService.name,
+          toService.version,
+          toService.hostIp,
+          requestUri,
+          statusInt,
+          duration,
+          callDepth)
+      }
+
+      producer.send(serverSpans)
+
+      Future(Unit)
+    }
+
+
+    val receiver = newKafkaSpanReceiver(process, keyDecoder = None, valueDecoder = StringDecoder)
+
+    val closer = Closable.sequence(receiver)
+    closeOnExit(closer)
+
+    logger.info("running and ready")
+    Await.all(receiver)
+  }
+}

--- a/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/SpanUtils.scala
+++ b/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/SpanUtils.scala
@@ -1,0 +1,60 @@
+package org.coursera.zipkin.courrelate
+
+import com.twitter.zipkin.{thriftscala => thrift}
+import com.twitter.zipkin.thriftscala.AnnotationType
+import com.twitter.zipkin.thriftscala.BinaryAnnotation
+
+object SpanUtils {
+  def printSpan(span: thrift.Span): String = {
+    val annotations = span.annotations.map( a =>
+      s"(ts=${a.timestamp}, host=${a.host}, dur=${a.duration}, val=${a.value})").mkString(",")
+    val binaryAnnotations = span.binaryAnnotations.map { a =>
+
+      val valueString = getBinaryAnnotationValue(a).toString
+      s"(type=${a.annotationType}, host=${a.host}, key=${a.key}, val=$valueString)"
+    }.mkString(",\n  ")
+
+    s"""START SPAN ===
+       |Id: ${span.id}
+        |TraceId: ${span.traceId}
+        |ParentId: ${span.parentId}
+        |Annotations: $annotations
+        |Binary Annotations: $binaryAnnotations
+        |Name: ${span.name}
+        |=== END SPAN\n
+     """.stripMargin
+  }
+
+  def getServiceName(span: thrift.Span): Option[String] = {
+    val serviceName =
+      if (span != null) {
+        span.binaryAnnotations.find(_.key == "requestUri").map(_.host.map(_.serviceName))
+      } else {
+        None
+      }
+    serviceName.flatten
+  }
+
+  def getBinaryAnnotationValue[T](span: thrift.Span, key: String): Option[T] = {
+    span.binaryAnnotations.find(_.key == key).map { ann =>
+      getBinaryAnnotationValue(ann).asInstanceOf[T]
+    }
+  }
+
+  def getBinaryAnnotationValue[T](ann: BinaryAnnotation): Any = {
+    val result = ann.annotationType match {
+      case AnnotationType.String =>
+        val buffer = ann.value
+        val arr = new Array[Byte](buffer.remaining)
+        buffer.get(arr)
+        new String(arr, "UTF-8")
+      case AnnotationType.I32 => ann.value.asIntBuffer().get()
+      case AnnotationType.I64 => ann.value.asLongBuffer().get()
+      case _ => throw new IllegalArgumentException("Unhandled AnnotationType: " + ann.annotationType)
+    }
+
+    ann.value.rewind()
+
+    result
+  }
+}

--- a/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/models.scala
+++ b/zipkin-courrelate/src/main/scala/org/coursera/zipkin/courrelate/models.scala
@@ -1,0 +1,29 @@
+package org.coursera.zipkin.courrelate
+
+import play.api.libs.json.Json
+
+case class ServiceInstance(
+  name: Option[String],
+  version: Option[String],
+  hostIp: Option[String])
+
+case class RichSpan(
+  timestamp: Long,
+  traceId: String,
+  spanId: Long,
+  parentSpanId: Option[Long],
+  fromServiceName: Option[String],
+  fromServiceVersion: Option[String],
+  fromServiceHostIp: Option[String],
+  toServiceName: Option[String],
+  toServiceVersion: Option[String],
+  toServiceHostIp: Option[String],
+  uri: String,
+  statusCode: Int,
+  duration: Long,
+  callDepth: Int)
+
+object Formats {
+  implicit val serviceInstanceFmt = Json.format[ServiceInstance]
+  implicit val richSpanFmt = Json.format[RichSpan]
+}

--- a/zipkin-prod-receiver/src/main/scala/org/coursera/zipkin/Main.scala
+++ b/zipkin-prod-receiver/src/main/scala/org/coursera/zipkin/Main.scala
@@ -1,0 +1,53 @@
+package org.coursera.zipkin
+
+import com.twitter.logging.Logger
+import com.twitter.scrooge.BinaryThriftStructSerializer
+import com.twitter.util.Base64StringEncoder
+import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
+import com.twitter.zipkin.conversions.thrift._
+import com.twitter.server.{Closer, TwitterServer}
+import com.twitter.util.{Await, Closable, Future}
+import com.twitter.zipkin.receiver.kafka.KafkaProcessor
+import com.twitter.zipkin.receiver.kafka.KafkaSpanReceiverFactory
+import com.twitter.zipkin.{thriftscala => thrift}
+import scala.util.Try
+
+object StringDecoder extends KafkaProcessor.KafkaDecoder {
+  private[this] val deserializer = new BinaryThriftStructSerializer[thrift.Span] {
+    override val encoder = Base64StringEncoder
+    val codec = thrift.Span
+  }
+
+  override def fromBytes(
+    bytes: Array[Byte]): Option[List[thrift.Span]] = {
+
+    val s = new String(bytes)
+    Some(s.split(",").flatMap(d => Try(deserializer.fromString(d)).toOption).toList)
+  }
+}
+
+object Main extends TwitterServer with Closer
+  with KafkaSpanReceiverFactory
+  with CassieSpanStoreFactory
+{
+  def main() {
+    val logger = Logger.get("Main")
+    val store = newCassandraStore()
+
+    def process(spans: Seq[thrift.Span]): Future[Unit] = {
+      val converted = spans.map(_.toSpan)
+      store(converted) rescue {
+        case t: Throwable =>
+          logger.error("Error while writing span.", t)
+          Future.value(())
+      }
+    }
+
+    val receiver = newKafkaSpanReceiver(process, keyDecoder = None, valueDecoder = StringDecoder)
+    val closer = Closable.sequence(receiver, store)
+    closeOnExit(closer)
+
+    println("running and ready")
+    Await.all(receiver, store)
+  }
+}

--- a/zipkin-prod-web/src/main/scala/org/coursera/zipkin/Main.scala
+++ b/zipkin-prod-web/src/main/scala/org/coursera/zipkin/Main.scala
@@ -1,0 +1,31 @@
+package org.coursera.zipkin
+
+import com.twitter.logging.Logger
+import com.twitter.zipkin.cassandra.CassieSpanStoreFactory
+import com.twitter.finagle.Http
+import com.twitter.server.{Closer, TwitterServer}
+import com.twitter.util.{Await, Closable}
+import com.twitter.zipkin.web.ZipkinWebFactory
+import com.twitter.zipkin.query.ThriftQueryService
+import com.twitter.zipkin.query.constants.DefaultAdjusters
+
+
+object Main extends TwitterServer with Closer
+  with ZipkinWebFactory
+  with CassieSpanStoreFactory
+{
+  def main() {
+    val logger = Logger.get("Main")
+    val store = newCassandraStore()
+
+    val query = new ThriftQueryService(store, adjusters = DefaultAdjusters)
+    val webService = newWebServer(query, statsReceiver.scope("web"))
+    val web = Http.serve(webServerPort(), webService)
+
+    val closer = Closable.sequence(web, store)
+    closeOnExit(closer)
+
+    println("running and ready")
+    Await.all(web, store)
+  }
+}


### PR DESCRIPTION
Add courrelate zipkin consumer, split zipkin-prod into web and receiver modules to speed up query performance. Code is a bit sloppy (cut/paste in build, courrelate consumer is not the cleanest), but this is in prototype mode as we build out courrelate. CC @danchia 
